### PR TITLE
役職設定一覧表示

### DIFF
--- a/TheOtherRoles/Patches/MapPatch.cs
+++ b/TheOtherRoles/Patches/MapPatch.cs
@@ -136,6 +136,7 @@ namespace TheOtherRoles.Patches
                     useButtonPos = HudManager.Instance.UseButton.transform.localPosition;
                 }
                 CustomOverlays.hideInfoOverlay();
+                CustomOverlays.hideRoleOverlay();
             }
 
             static void Postfix(MapBehaviour __instance)

--- a/TheOtherRoles/Patches/MeetingPatch.cs
+++ b/TheOtherRoles/Patches/MeetingPatch.cs
@@ -688,6 +688,7 @@ namespace TheOtherRoles.Patches {
             animateSwap = false;
             CustomOverlays.showBlackBG();
             CustomOverlays.hideInfoOverlay();
+            CustomOverlays.hideRoleOverlay();
             TheOtherRolesGM.OnMeetingStart();
         }
 

--- a/TheOtherRoles/Roles/CustomRolesGM.cs
+++ b/TheOtherRoles/Roles/CustomRolesGM.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Linq;
 using BepInEx;
 using BepInEx.Configuration;
@@ -78,6 +78,7 @@ namespace TheOtherRoles
             Modifier.allModifiers.Do(x => x.OnMeetingEnd());
 
             CustomOverlays.hideInfoOverlay();
+            CustomOverlays.hideRoleOverlay();
             CustomOverlays.hideBlackBG();
         }
 


### PR DESCRIPTION
移動中または会議中にIキーで役職設定一覧(ロビーで表示されるのと同じもの)を表示できます。
複数ページある場合はIキーでページ送りでき、最終ページでIキーを押すと一覧が消えます。