### PR TITLE
ミディアムのチャットが伏せられる問題を修正

### DIFF
--- a/TheOtherRoles/Buttons.cs
+++ b/TheOtherRoles/Buttons.cs
@@ -1307,7 +1307,10 @@ namespace TheOtherRoles
                     else if (randomNumber == 2) msg = string.Format(ModTranslation.getString("mediumQuestion3"), Math.Round(timeSinceDeath / 1000)) + name;
                     else msg = string.Format(ModTranslation.getString("mediumQuestion4"), RoleInfo.GetRolesString(Medium.target.killerIfExisting, false, includeHidden: true)) + name; ; // Excludes mini 
 
+                    bool CensorChat = SaveManager.CensorChat;
+                    if (CensorChat) SaveManager.CensorChat = false;
                     DestroyableSingleton<HudManager>.Instance.Chat.AddChat(PlayerControl.LocalPlayer, $"{msg}");
+                    SaveManager.CensorChat = CensorChat;
 
                     // Remove soul
                     if (Medium.oneTimeUse)


### PR DESCRIPTION
ミディアムのチャットの文字が***に書き換わる問題を修正
- ミディアムのチャットは検閲対象外になるように設定