### PR TITLE
最初の試合で殺されると発生する例外の修正

### DIFF
--- a/TheOtherRoles/Roles/Role.cs
+++ b/TheOtherRoles/Roles/Role.cs
@@ -620,7 +620,7 @@ namespace TheOtherRoles
             if (player.isLovers())
                 Lovers.killLovers(player, killer);
 
-            if(MeetingHud.Instance.state != MeetingHud.VoteStates.Animating)
+            if(MeetingHud.Instance?.state != MeetingHud.VoteStates.Animating)
                 RPCProcedure.updateMeeting(player.PlayerId, true);
         }
     }


### PR DESCRIPTION
最初の試合で一度も会議が呼ばれる前に殺害が起こると例外が発生する問題を修正
- MeetingHudにNullチェックを追加