### PR TITLE
ゲッサーの残弾数管理の修正と微修正

### DIFF
--- a/TheOtherRoles/Patches/MeetingPatch.cs
+++ b/TheOtherRoles/Patches/MeetingPatch.cs
@@ -420,7 +420,7 @@ namespace TheOtherRoles.Patches {
                 {
                     guesserRole = RoleType.NiceGuesser;
                 }
-                else if(PlayerControl.LocalPlayer.isRole(RoleType.EvilGuesser))
+                else if(PlayerControl.LocalPlayer.isRole(RoleType.EvilGuesser) || PlayerControl.LocalPlayer.hasModifier(ModifierType.LastImpostor))
                 {
                     guesserRole = RoleType.EvilGuesser;
                 }
@@ -468,17 +468,7 @@ namespace TheOtherRoles.Patches {
                     } else {
                         PlayerControl focusedTarget = Helpers.playerById((byte)__instance.playerStates[buttonTarget].TargetPlayerId);
                         if (!(__instance.state == MeetingHud.VoteStates.Voted || __instance.state == MeetingHud.VoteStates.NotVoted) || focusedTarget == null) return;
-                        if (Guesser.isGuesser(PlayerControl.LocalPlayer.PlayerId))
-                        {
-                            if(PlayerControl.LocalPlayer.hasModifier(ModifierType.LastImpostor))
-                            {
-                                if(Guesser.remainingShots(PlayerControl.LocalPlayer.PlayerId) + LastImpostor.remainingShots <= 0) return;
-                            }
-                            else
-                            {
-                                if(Guesser.remainingShots(PlayerControl.LocalPlayer.PlayerId) <= 0) return;
-                            }
-                        }
+                        if(Guesser.remainingShots(PlayerControl.LocalPlayer) <= 0) return;
 
                         if (!Guesser.killsThroughShield && focusedTarget == Medic.shielded) { // Depending on the options, shooting the shielded player will not allow the guess, notifiy everyone about the kill attempt and close the window
                             __instance.playerStates.ToList().ForEach(x => x.gameObject.SetActive(true)); 
@@ -512,7 +502,7 @@ namespace TheOtherRoles.Patches {
                         // Reset the GUI
                         __instance.playerStates.ToList().ForEach(x => x.gameObject.SetActive(true));
                         UnityEngine.Object.Destroy(container.gameObject);
-                        if (Guesser.hasMultipleShotsPerMeeting && (Guesser.remainingShots(PlayerControl.LocalPlayer.PlayerId) > 0 || LastImpostor.remainingShots > 0) && dyingTarget != PlayerControl.LocalPlayer)
+                        if (Guesser.hasMultipleShotsPerMeeting && Guesser.remainingShots(PlayerControl.LocalPlayer) > 1 && dyingTarget != PlayerControl.LocalPlayer)
                         {
                             __instance.playerStates.ToList().ForEach(x => { if (x.TargetPlayerId == dyingTarget.PlayerId && x.transform.FindChild("ShootButton") != null) UnityEngine.Object.Destroy(x.transform.FindChild("ShootButton").gameObject); });
                         }
@@ -617,8 +607,8 @@ namespace TheOtherRoles.Patches {
             }
 
             // Add Guesser Buttons
-            bool isGuesserButton = Guesser.isGuesser(PlayerControl.LocalPlayer.PlayerId) && PlayerControl.LocalPlayer.isAlive() && Guesser.remainingShots(PlayerControl.LocalPlayer.PlayerId) > 0;
-            bool isLastImpostorButton = PlayerControl.LocalPlayer.hasModifier(ModifierType.LastImpostor) && LastImpostor.remainingShots > 0 && LastImpostor.selectedFunction == 1 && LastImpostor.isCounterMax();
+            bool isGuesserButton = Guesser.isGuesser(PlayerControl.LocalPlayer.PlayerId) && PlayerControl.LocalPlayer.isAlive() && Guesser.remainingShots(PlayerControl.LocalPlayer) > 0;
+            bool isLastImpostorButton = PlayerControl.LocalPlayer.hasModifier(ModifierType.LastImpostor) && PlayerControl.LocalPlayer.isAlive() && LastImpostor.canGuess();
             if (isGuesserButton || isLastImpostorButton) {
                 for (int i = 0; i < __instance.playerStates.Length; i++) {
                     PlayerVoteArea playerVoteArea = __instance.playerStates[i];
@@ -666,15 +656,7 @@ namespace TheOtherRoles.Patches {
                 meetingInfoText.gameObject.SetActive(true);
             }
 
-            int numGuesses = 0;
-            if (Guesser.isGuesser(PlayerControl.LocalPlayer.PlayerId))
-            {
-                numGuesses += Guesser.remainingShots(PlayerControl.LocalPlayer.PlayerId);
-            }
-            if(PlayerControl.LocalPlayer.hasModifier(ModifierType.LastImpostor))
-            {
-                numGuesses += LastImpostor.remainingShots;
-            }
+            int numGuesses = Guesser.remainingShots(PlayerControl.LocalPlayer);
             if ((Guesser.isGuesser(PlayerControl.LocalPlayer.PlayerId) || PlayerControl.LocalPlayer.hasModifier(ModifierType.LastImpostor)) && PlayerControl.LocalPlayer.isAlive() && numGuesses > 0)
             {
                 meetingInfoText.text = String.Format(ModTranslation.getString("guesserGuessesLeft"), numGuesses);

--- a/TheOtherRoles/RPC.cs
+++ b/TheOtherRoles/RPC.cs
@@ -841,15 +841,7 @@ namespace TheOtherRoles
             dyingTarget.Exiled();
             PlayerControl dyingLoverPartner = Lovers.bothDie ? dyingTarget.getPartner() : null; // Lover check
 
-            // ラストインポスターの弾数を優先的に消費させる
-            if(killer.hasModifier(ModifierType.LastImpostor) && LastImpostor.remainingShots > 0)
-            {
-                LastImpostor.remainingShots = Mathf.Max(0, LastImpostor.remainingShots - 1);
-            }
-            else
-            {
-                Guesser.remainingShots(killerId, true);
-            }
+            Guesser.remainingShots(killer, true);
 
             if (Constants.ShouldPlaySfx()) SoundManager.Instance.PlaySound(dyingTarget.KillSfx, false, 0.8f);
 

--- a/TheOtherRoles/Roles/Modifiers/LastImpostor.cs
+++ b/TheOtherRoles/Roles/Modifiers/LastImpostor.cs
@@ -218,6 +218,10 @@ namespace TheOtherRoles
             return false;
         }
 
+        public static bool canGuess(){
+            return remainingShots > 0 && selectedFunction == 1 && isCounterMax();
+        }
+
         public static void promoteToLastImpostor()
         {
             if(!isEnable) return;

--- a/TheOtherRoles/TheOtherRoles.cs
+++ b/TheOtherRoles/TheOtherRoles.cs
@@ -1068,13 +1068,30 @@ namespace TheOtherRoles
                 else if (evilGuesser != null && evilGuesser.PlayerId == playerId) evilGuesser = null;
             }
 
-            public static int remainingShots(byte playerId, bool shoot = false) {
-                int remainingShots = remainingShotsEvilGuesser;
-                if (niceGuesser != null && niceGuesser.PlayerId == playerId) {
+            public static int remainingShots(PlayerControl player, bool shoot = false) {
+                int remainingShots = 0;
+                if (niceGuesser == player) {
                     remainingShots = remainingShotsNiceGuesser;
                     if (shoot) remainingShotsNiceGuesser = Mathf.Max(0, remainingShotsNiceGuesser - 1);
-                } else if (shoot) {
-                    remainingShotsEvilGuesser = Mathf.Max(0, remainingShotsEvilGuesser - 1);
+                } else if (evilGuesser == player) {
+                    remainingShots = remainingShotsEvilGuesser;
+                    if(player.hasModifier(ModifierType.LastImpostor) && LastImpostor.canGuess()) {
+		                remainingShots += LastImpostor.remainingShots;
+		            }
+                    if (shoot) {
+                        // ラストインポスターの弾数を優先的に消費させる
+			            if(player.hasModifier(ModifierType.LastImpostor) && LastImpostor.canGuess())
+			            {
+			                LastImpostor.remainingShots = Mathf.Max(0, LastImpostor.remainingShots - 1);
+			            }
+			            else
+			            {
+                    		remainingShotsEvilGuesser = Mathf.Max(0, remainingShotsEvilGuesser - 1);
+                    	}
+                    }
+                } else if(player.hasModifier(ModifierType.LastImpostor) && LastImpostor.canGuess()) {
+                    remainingShots = LastImpostor.remainingShots;
+                    if (shoot) LastImpostor.remainingShots = Mathf.Max(0, LastImpostor.remainingShots - 1);
                 }
                 return remainingShots;
             }

--- a/TheOtherRoles/TheOtherRoles.cs
+++ b/TheOtherRoles/TheOtherRoles.cs
@@ -1076,18 +1076,18 @@ namespace TheOtherRoles
                 } else if (evilGuesser == player) {
                     remainingShots = remainingShotsEvilGuesser;
                     if(player.hasModifier(ModifierType.LastImpostor) && LastImpostor.canGuess()) {
-		                remainingShots += LastImpostor.remainingShots;
-		            }
+                        remainingShots += LastImpostor.remainingShots;
+                    }
                     if (shoot) {
                         // ラストインポスターの弾数を優先的に消費させる
-			            if(player.hasModifier(ModifierType.LastImpostor) && LastImpostor.canGuess())
-			            {
-			                LastImpostor.remainingShots = Mathf.Max(0, LastImpostor.remainingShots - 1);
-			            }
-			            else
-			            {
-                    		remainingShotsEvilGuesser = Mathf.Max(0, remainingShotsEvilGuesser - 1);
-                    	}
+                        if(player.hasModifier(ModifierType.LastImpostor) && LastImpostor.canGuess())
+                        {
+                            LastImpostor.remainingShots = Mathf.Max(0, LastImpostor.remainingShots - 1);
+                        }
+                        else
+                        {
+                            remainingShotsEvilGuesser = Mathf.Max(0, remainingShotsEvilGuesser - 1);
+                        }
                     }
                 } else if(player.hasModifier(ModifierType.LastImpostor) && LastImpostor.canGuess()) {
                     remainingShots = LastImpostor.remainingShots;


### PR DESCRIPTION
ラストインポスターの残弾数がおかしくなる問題について、以下の原因で起こっていたようです。
１．ゲッサー(自分がナイスゲッサーならナイスゲッサー、それ以外ならイビルゲッサー)かラストインポスターいずれかの減らす前の残弾数が0より大きければ照準を残すようになっていた
２．ゲッサーが撃ったとき、残弾数が0以下なら中断する処理があったがゲッサーのみの分岐となっていたためラストインポスターはそこを通っていなかった

ナイスゲッサー(弾数1)の場合
→１によって撃った直後に照準は消えないが、２で中断されるため実際には2発目以降が撃てなくなっていた
ラストインポスター(弾数1)の場合(イビルゲッサー(0%)の弾数1)
→１によって撃った直後に照準が消えず、２で中断されないため2発目が撃てた。(ラストインポスター弾数1→0、イビルゲッサー弾数1)
　2発目を撃ったあともイビルゲッサーの減らす前の弾数が0より大きいため照準が消えず、２で中断されないため3発目が撃てた。(ラストインポスター弾数0、イビルゲッサー弾数1→0)
　3発目を撃った際はラストインポスター、イビルゲッサーとも減らす前の残弾0となっているため、照準が消え、それ以上撃てなくなった。
のようになっていたのではないかと思われます。

１．の対策として、
ゲッサーの残弾を数える処理(Guesser.remainingShots)を
指定プレイヤーがナイスゲッサーならナイスゲッサー、それ以外ならイビルゲッサーの残弾を返す処理
↓
指定プレイヤーが
　ナイスゲッサーならナイスゲッサーの残弾
　イビルゲッサーかつ※ラストインポスターならイビルゲッサー＋ラストインポスターの残弾
　イビルゲッサーならイビルゲッサーの残弾
　※ラストインポスターならラストインポスターの残弾
　上記以外なら0
を返す処理に変更し、戻り値が1より大きければ照準を残すようにしました。

また、同様の処理を行っていた残弾数表示・弾数消費をこの処理を呼び出すよう変更しました。

２．の対策として、役職関係なく上記の処理を呼び、戻り値が0以下なら中断するようにしました。
ゲッサーでもラストインポスターでも残弾数が0以下なら中断されるはずです。多分。

※ラストインポスターについて
ラストインポスターのゲッサー能力獲得条件(残弾数が0より多い、かつラストインポスター種別がゲッサー、かつ指定人数キルしている)を判断している箇所が照準表示条件しかなかったため、無条件で照準を表示できるイビルゲッサーがラストインポスターだと種別が占い師でも、キル数を満たしてなくてもラストインポスター分弾数が加算されるようになっていました。
ゲッサー能力を獲得しているかどうか(canGuess)をLastImpostor.csに追加し、残弾数計算時に参照することで種別やキル数を満たしていないときに弾数が加算されないようにしました。

ついでに、
・ラストインポスターの選択肢にナイスゲッサーが出てこない
→代わりにイビルゲッサーが出てこなくなりましたが、ラストインポスター（＝他にインポスターがいない）状態でイビルゲッサーを撃ちたい場面がありそうにないと思ったのでいいかなと思いました。
・ラストインポスターの照準表示条件に生存を追加
→たぶん、死亡状態で撃てる必要がある場面はないはず…？
を修正しました。

一応動作検証はしたのですが、何かおかしかったらすみません。