### PR TITLE
AirShipの配線追加の例外を修正

### DIFF
--- a/TheOtherRoles/Patches/AirshipPatch.cs
+++ b/TheOtherRoles/Patches/AirshipPatch.cs
@@ -88,6 +88,11 @@ namespace TheOtherRoles.Patches
         protected static Console ActivateConsole(string objectName)
         {
             GameObject obj = UnityEngine.GameObject.Find(objectName);
+            if (obj == null)
+            {
+                Logger.error($"Object \"{objectName}\" was not found!", "ActivateConsole");
+                return null;
+            }
             obj.layer = LayerMask.NameToLayer("ShortObjects");
             Console console = obj.GetComponent<Console>();
             PassiveButton button = obj.GetComponent<PassiveButton>();

--- a/TheOtherRoles/Patches/AirshipPatch.cs
+++ b/TheOtherRoles/Patches/AirshipPatch.cs
@@ -76,6 +76,12 @@ namespace TheOtherRoles.Patches
         {
             Console console = ActivateConsole(consoleName);
 
+            if (console == null)
+            {
+                Logger.error($"consoleName \"{consoleName}\" is null", "ActivateWiring");
+                return null;
+            }
+
             if (!console.TaskTypes.Contains(TaskTypes.FixWiring))
             {
                 var list=console.TaskTypes.ToList();

--- a/TheOtherRoles/Patches/AirshipPatch.cs
+++ b/TheOtherRoles/Patches/AirshipPatch.cs
@@ -65,7 +65,7 @@ namespace TheOtherRoles.Patches
                 ActivateWiring("task_wiresHallway2", 2);
                 ActivateWiring("task_electricalside2", 3).Room = SystemTypes.Armory;
                 ActivateWiring("task_wireShower", 4);
-                ActivateWiring("task_wiresLounge", 5);
+                ActivateWiring("taks_wiresLounge", 5);
                 ActivateWiring("panel_wireHallwayL", 6);
                 ActivateWiring("task_wiresStorage", 7);
                 ActivateWiring("task_electricalSide", 8).Room = SystemTypes.VaultRoom;


### PR DESCRIPTION
・ラウンジ配線のオブジェクト名を修正
・オブジェクトが見つからなかったときにログでエラーを出力するように