### PR TITLE
ログの追加

### DIFF
--- a/TheOtherRoles/Helpers.cs
+++ b/TheOtherRoles/Helpers.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using System;
+using System.Text;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -689,6 +690,13 @@ namespace TheOtherRoles {
             if (num == 254) name = "None";
             if (num == 255) name = "Dead";
             return name;
+        }
+        public static string PadRightV2(this object text, int num)
+        {
+            int bc = 0;
+            var t = text.ToString();
+            foreach (char c in t) bc += Encoding.GetEncoding("UTF-8").GetByteCount(c.ToString()) == 1 ? 1 : 2;
+            return t?.PadRight(num - (bc - t.Length));
         }
     }
 }

--- a/TheOtherRoles/Modules/CustomHats.cs
+++ b/TheOtherRoles/Modules/CustomHats.cs
@@ -200,7 +200,7 @@ namespace TheOtherRoles.Modules
                     }
                     while (CustomHatLoader.hatDetails.Count > 0) {
                         __instance.allHats.Add(CreateHatData(CustomHatLoader.hatDetails[0]));
-                        Logger.info(String.Format("Add CustomHat Author:{0,-20}Name:{1}", CustomHatLoader.hatDetails[0].author, CustomHatLoader.hatDetails[0].name), "CustomHats");
+                        Logger.info(String.Format("Add CustomHat Author:{0} Name:{1}", CustomHatLoader.hatDetails[0].author.PadRightV2(20), CustomHatLoader.hatDetails[0].name), "CustomHats");
                         CustomHatLoader.hatDetails.RemoveAt(0);
                     }
                 } catch (System.Exception e) {

--- a/TheOtherRoles/MorphHandler.cs
+++ b/TheOtherRoles/MorphHandler.cs
@@ -1,4 +1,5 @@
-﻿namespace TheOtherRoles
+﻿using System.Diagnostics;
+namespace TheOtherRoles
 {
     public static class MorphHandler
     {
@@ -9,6 +10,9 @@
 
         public static void setOutfit(this PlayerControl pc, GameData.PlayerOutfit outfit, bool visible = true)
         {
+            StackFrame stack1 = new(1);
+            StackFrame stack2 = new(2);
+            Logger.info($"{pc?.getNameWithRole()} => {outfit?.PlayerName} at {stack1.GetMethod().Name} at {stack2.GetMethod().Name}", "setOutfit");
             pc.Data.Outfits[PlayerOutfitType.Shapeshifted] = outfit;
             pc.CurrentOutfitType = PlayerOutfitType.Shapeshifted;
 

--- a/TheOtherRoles/Objects/CustomButton.cs
+++ b/TheOtherRoles/Objects/CustomButton.cs
@@ -72,6 +72,7 @@ namespace TheOtherRoles.Objects {
             if ((this.HasEffect && this.isEffectActive && this.effectCancellable) || this.Timer < 0f && HasButton() && CouldUse())
             {
                 actionButton.graphic.color = new Color(1f, 1f, 1f, 0.3f);
+                Logger.info($"Click \"{((this.buttonText is null or "") && hotkey is not null ? Enum.GetName(typeof(KeyCode), hotkey) : this.buttonText)}\"", "Button");
                 this.OnClick();
 
                 if (this.HasEffect && !this.isEffectActive) {

--- a/TheOtherRoles/Patches/EndGamePatch.cs
+++ b/TheOtherRoles/Patches/EndGamePatch.cs
@@ -707,7 +707,7 @@ namespace TheOtherRoles.Patches
                             return x.Status.CompareTo(y.Status);
 
                         });
-
+                        Logger.info(textRenderer.text, "Result");
                         bool plagueExists = AdditionalTempData.playerRoles.Any(x => x.Roles.Contains(RoleInfo.plagueDoctor));
                         Logger.info("----------Game Result-----------", "Result");
                         foreach (var data in AdditionalTempData.playerRoles)

--- a/TheOtherRoles/Patches/GameStartManagerPatch.cs
+++ b/TheOtherRoles/Patches/GameStartManagerPatch.cs
@@ -15,10 +15,22 @@ namespace TheOtherRoles.Patches {
         private static bool versionSent = false;
         private static string lobbyCodeText = "";
 
+        [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.OnBecomeHost))]
+        public class AmongUsClientOnBecomeHostPatch {
+            public static void Postfix(AmongUsClient __instance) {
+                Logger.info($"My Player ID:{__instance.ClientId} Now Become Host", "Session");
+            }
+        }
         [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.OnGameJoined))]
         public class AmongUsClientOnGameJoinedPatch {
             public static void Postfix(AmongUsClient __instance) {
                 Logger.info($"My Player ID:{__instance.ClientId} Joined", "Session");
+            }
+        }
+        [HarmonyPatch(typeof(AmongUsClient), nameof(AmongUsClient.ExitGame))]
+        public class AmongUsClientOnDisconnectedPatch {
+            public static void Prefix(AmongUsClient __instance) {
+                Logger.info($"My Player ID:{__instance.ClientId} Exit", "Session");
             }
         }
 

--- a/TheOtherRoles/Patches/IntroPatch.cs
+++ b/TheOtherRoles/Patches/IntroPatch.cs
@@ -200,10 +200,10 @@ namespace TheOtherRoles.Patches {
 
                 Logger.info("----------Role Assign-----------", "Settings");
                 foreach (var pc in PlayerControl.AllPlayerControls)
-                    Logger.info(String.Format("{0,-3}{1,-2}:{2,-16}:{3}", pc.AmOwner ? "[*]" : "", pc.PlayerId, pc.Data.PlayerName, RoleInfo.GetRolesString(pc, false, joinSeparator:" + ")), "Settings");
+                    Logger.info(String.Format("{0,-3}{1,-2}:{2}:{3}", pc.AmOwner ? "[*]" : "", pc.PlayerId, pc.Data.PlayerName.PadRightV2(20), RoleInfo.GetRolesString(pc, false, joinSeparator:" + ")), "Settings");
                 Logger.info("-----------Platforms------------", "Settings");
                 foreach (var pc in PlayerControl.AllPlayerControls)
-                    Logger.info(String.Format("{0,-3}{1,-2}:{2,-16}:{3}", pc.AmOwner ? "[*]" : "", pc.PlayerId, pc.Data.PlayerName, pc.getPlatform().Replace("Standalone", "")), "Settings");
+                    Logger.info(String.Format("{0,-3}{1,-2}:{2}:{3}", pc.AmOwner ? "[*]" : "", pc.PlayerId, pc.Data.PlayerName.PadRightV2(20), pc.getPlatform().Replace("Standalone", "")), "Settings");
                 Logger.info("---------Game Settings----------", "Settings");
                 TheOtherRolesPlugin.optionsPage = 0;
                 var tmp = PlayerControl.GameOptions.ToHudString(GameData.Instance ? GameData.Instance.PlayerCount : 10).Split("\r\n");
@@ -212,7 +212,7 @@ namespace TheOtherRoles.Patches {
                 Logger.info("--------Advance Settings--------", "Settings");
                 foreach (var o in CustomOption.options)
                     if (o.parent == null ? !o.getString().Equals("0%") : o.parent.enabled)
-                        Logger.info(String.Format("{0}{1,-36}:{2}", o.parent == null ? "" : "┗ ", o.name.removeHtml(), o.getString().removeHtml()), "Settings");
+                        Logger.info(String.Format("{0}:{1}", o.parent == null ? o.name.removeHtml().PadRightV2(43) : $"┗ {o.name.removeHtml().PadRightV2(41)}", o.getString().removeHtml()), "Settings");
                 Logger.info("--------------------------------", "Settings");
 
                 __instance.YouAreText.color = roleInfo.color;

--- a/TheOtherRoles/Patches/MeetingPatch.cs
+++ b/TheOtherRoles/Patches/MeetingPatch.cs
@@ -102,7 +102,7 @@ namespace TheOtherRoles.Patches
                     PlayerVoteArea playerVoteArea = __instance.playerStates[i];
                     byte votedTarget = playerVoteArea.TargetPlayerId;
                     byte votedFor = playerVoteArea.VotedFor;
-                    Logger.info(String.Format("{0,-2}({1,-32}):{2,-3}({3})", votedTarget, Helpers.getVoteName(votedTarget), votedFor, Helpers.getVoteName(votedFor)), "Vote");
+                    Logger.info(String.Format("{0,-2}{1}:{2,-3}{3}", votedTarget, $"({Helpers.getVoteName(votedTarget)})".PadRightV2(40), votedFor, Helpers.getVoteName(votedFor)), "Vote");
                     if (votedFor != 252 && votedFor != 255 && votedFor != 254) {
                         PlayerControl player = Helpers.playerById((byte)playerVoteArea.TargetPlayerId);
                         if (player == null || player.Data == null || player.Data.IsDead || player.Data.Disconnected || player.isGM()) continue;

--- a/TheOtherRoles/Patches/PlayerControlPatch.cs
+++ b/TheOtherRoles/Patches/PlayerControlPatch.cs
@@ -14,6 +14,7 @@ namespace TheOtherRoles.Patches
     [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.FixedUpdate))]
     public static class PlayerControlFixedUpdatePatch
     {
+        private static Dictionary<byte, bool> lastVisible = new();
         // Helpers
 
         public static PlayerControl setTarget(bool onlyCrewmates = false, bool targetPlayersInVents = false, List<PlayerControl> untargetablePlayers = null, PlayerControl targetingPlayer = null)
@@ -1069,6 +1070,9 @@ namespace TheOtherRoles.Patches
 
         public static void Postfix(PlayerControl __instance)
         {
+            if (lastVisible.TryGetValue(__instance.PlayerId, out bool visible) && __instance.Visible != visible)
+                Logger.info($"Visible Status Change to {__instance.Visible} for {__instance.getNameWithRole()}", "BodySprite");
+            lastVisible[__instance.PlayerId] = __instance.Visible;
             if (AmongUsClient.Instance.GameState != InnerNet.InnerNetClient.GameStates.Started) return;
 
             // Mini and Morphling shrink

--- a/TheOtherRoles/RPC.cs
+++ b/TheOtherRoles/RPC.cs
@@ -1300,6 +1300,19 @@ namespace TheOtherRoles
         [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.HandleRpc))]
         class RPCHandlerPatch
         {
+            public static bool Prefix(PlayerControl __instance, [HarmonyArgument(0)] byte callId, [HarmonyArgument(1)] MessageReader reader)
+            {
+                var rpcType = (RpcCalls)callId;
+                MessageReader subReader = MessageReader.Get(reader);
+                switch (rpcType)
+                {
+                    case RpcCalls.StartMeeting:
+                        var p = Helpers.getPlayerById(subReader.ReadByte());
+                        Logger.info($"{__instance.getNameWithRole()} => {p?.getNameWithRole() ?? "null"}", "StartMeeting");
+                        break;
+                }
+                return true;
+            }
             static void Postfix([HarmonyArgument(0)] byte callId, [HarmonyArgument(1)] MessageReader reader)
             {
                 byte packetId = callId;

--- a/TheOtherRoles/RPC.cs
+++ b/TheOtherRoles/RPC.cs
@@ -1316,361 +1316,365 @@ namespace TheOtherRoles
             static void Postfix([HarmonyArgument(0)] byte callId, [HarmonyArgument(1)] MessageReader reader)
             {
                 byte packetId = callId;
-                switch (packetId)
-                {
+                try{
+                    switch (packetId)
+                    {
 
-                    // Main Controls
+                        // Main Controls
 
-                    case (byte)CustomRPC.ResetVariables:
-                        RPCProcedure.resetVariables();
-                        break;
-                    case (byte)CustomRPC.ShareOptions:
-                        RPCProcedure.ShareOptions((int)reader.ReadPackedUInt32(), reader);
-                        break;
-                    case (byte)CustomRPC.ForceEnd:
-                        RPCProcedure.forceEnd();
-                        break;
-                    case (byte)CustomRPC.SetRole:
-                        byte roleId = reader.ReadByte();
-                        byte playerId = reader.ReadByte();
-                        byte flag = reader.ReadByte();
-                        RPCProcedure.setRole(roleId, playerId, flag);
-                        break;
-                    case (byte)CustomRPC.SetLovers:
-                        RPCProcedure.setLovers(reader.ReadByte(), reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.OverrideNativeRole:
-                        RPCProcedure.overrideNativeRole(reader.ReadByte(), reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.VersionHandshake:
-                        int major = reader.ReadPackedInt32();
-                        int minor = reader.ReadPackedInt32();
-                        int patch = reader.ReadPackedInt32();
-                        int versionOwnerId = reader.ReadPackedInt32();
-                        byte revision = 0xFF;
-                        Guid guid;
-                        if (reader.Length - reader.Position >= 17)
-                        { // enough bytes left to read
-                            revision = reader.ReadByte();
-                            // GUID
-                            byte[] gbytes = reader.ReadBytes(16);
-                            guid = new Guid(gbytes);
-                        }
-                        else
-                        {
-                            guid = new Guid(new byte[16]);
-                        }
-                        RPCProcedure.versionHandshake(major, minor, patch, revision == 0xFF ? -1 : revision, guid, versionOwnerId);
-                        break;
-                    case (byte)CustomRPC.UseUncheckedVent:
-                        int ventId = reader.ReadPackedInt32();
-                        byte ventingPlayer = reader.ReadByte();
-                        byte isEnter = reader.ReadByte();
-                        RPCProcedure.useUncheckedVent(ventId, ventingPlayer, isEnter);
-                        break;
-                    case (byte)CustomRPC.UncheckedMurderPlayer:
-                        byte source = reader.ReadByte();
-                        byte target = reader.ReadByte();
-                        byte showAnimation = reader.ReadByte();
-                        RPCProcedure.uncheckedMurderPlayer(source, target, showAnimation);
-                        break;
-                    case (byte)CustomRPC.UncheckedExilePlayer:
-                        byte exileTarget = reader.ReadByte();
-                        RPCProcedure.uncheckedExilePlayer(exileTarget);
-                        break;
-                    case (byte)CustomRPC.UncheckedCmdReportDeadBody:
-                        byte reportSource = reader.ReadByte();
-                        byte reportTarget = reader.ReadByte();
-                        RPCProcedure.uncheckedCmdReportDeadBody(reportSource, reportTarget);
-                        break;
-                    case (byte)CustomRPC.UncheckedEndGame:
-                        RPCProcedure.uncheckedEndGame(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.UncheckedSetTasks:
-                        RPCProcedure.uncheckedSetTasks(reader.ReadByte(), reader.ReadBytesAndSize());
-                        break;
-                    case (byte)CustomRPC.DynamicMapOption:
-	                    byte mapId = reader.ReadByte();
-	                    RPCProcedure.dynamicMapOption(mapId);
-	                    break;
+                        case (byte)CustomRPC.ResetVariables:
+                            RPCProcedure.resetVariables();
+                            break;
+                        case (byte)CustomRPC.ShareOptions:
+                            RPCProcedure.ShareOptions((int)reader.ReadPackedUInt32(), reader);
+                            break;
+                        case (byte)CustomRPC.ForceEnd:
+                            RPCProcedure.forceEnd();
+                            break;
+                        case (byte)CustomRPC.SetRole:
+                            byte roleId = reader.ReadByte();
+                            byte playerId = reader.ReadByte();
+                            byte flag = reader.ReadByte();
+                            RPCProcedure.setRole(roleId, playerId, flag);
+                            break;
+                        case (byte)CustomRPC.SetLovers:
+                            RPCProcedure.setLovers(reader.ReadByte(), reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.OverrideNativeRole:
+                            RPCProcedure.overrideNativeRole(reader.ReadByte(), reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.VersionHandshake:
+                            int major = reader.ReadPackedInt32();
+                            int minor = reader.ReadPackedInt32();
+                            int patch = reader.ReadPackedInt32();
+                            int versionOwnerId = reader.ReadPackedInt32();
+                            byte revision = 0xFF;
+                            Guid guid;
+                            if (reader.Length - reader.Position >= 17)
+                            { // enough bytes left to read
+                                revision = reader.ReadByte();
+                                // GUID
+                                byte[] gbytes = reader.ReadBytes(16);
+                                guid = new Guid(gbytes);
+                            }
+                            else
+                            {
+                                guid = new Guid(new byte[16]);
+                            }
+                            RPCProcedure.versionHandshake(major, minor, patch, revision == 0xFF ? -1 : revision, guid, versionOwnerId);
+                            break;
+                        case (byte)CustomRPC.UseUncheckedVent:
+                            int ventId = reader.ReadPackedInt32();
+                            byte ventingPlayer = reader.ReadByte();
+                            byte isEnter = reader.ReadByte();
+                            RPCProcedure.useUncheckedVent(ventId, ventingPlayer, isEnter);
+                            break;
+                        case (byte)CustomRPC.UncheckedMurderPlayer:
+                            byte source = reader.ReadByte();
+                            byte target = reader.ReadByte();
+                            byte showAnimation = reader.ReadByte();
+                            RPCProcedure.uncheckedMurderPlayer(source, target, showAnimation);
+                            break;
+                        case (byte)CustomRPC.UncheckedExilePlayer:
+                            byte exileTarget = reader.ReadByte();
+                            RPCProcedure.uncheckedExilePlayer(exileTarget);
+                            break;
+                        case (byte)CustomRPC.UncheckedCmdReportDeadBody:
+                            byte reportSource = reader.ReadByte();
+                            byte reportTarget = reader.ReadByte();
+                            RPCProcedure.uncheckedCmdReportDeadBody(reportSource, reportTarget);
+                            break;
+                        case (byte)CustomRPC.UncheckedEndGame:
+                            RPCProcedure.uncheckedEndGame(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.UncheckedSetTasks:
+                            RPCProcedure.uncheckedSetTasks(reader.ReadByte(), reader.ReadBytesAndSize());
+                            break;
+                        case (byte)CustomRPC.DynamicMapOption:
+                            byte mapId = reader.ReadByte();
+                            RPCProcedure.dynamicMapOption(mapId);
+                            break;
 
-                    // Role functionality
+                        // Role functionality
 
-                    case (byte)CustomRPC.EngineerFixLights:
-                        RPCProcedure.engineerFixLights();
-                        break;
-                    case (byte)CustomRPC.EngineerFixSubmergedOxygen:
-                        RPCProcedure.engineerFixSubmergedOxygen();
-                        break;
-                    case (byte)CustomRPC.EngineerUsedRepair:
-                        RPCProcedure.engineerUsedRepair();
-                        break;
-                    case (byte)CustomRPC.CleanBody:
-                        RPCProcedure.cleanBody(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.SheriffKill:
-                        RPCProcedure.sheriffKill(reader.ReadByte(), reader.ReadByte(), reader.ReadBoolean());
-                        break;
-                    case (byte)CustomRPC.TimeMasterRewindTime:
-                        RPCProcedure.timeMasterRewindTime();
-                        break;
-                    case (byte)CustomRPC.TimeMasterShield:
-                        RPCProcedure.timeMasterShield();
-                        break;
-                    case (byte)CustomRPC.MedicSetShielded:
-                        RPCProcedure.medicSetShielded(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.ShieldedMurderAttempt:
-                        RPCProcedure.shieldedMurderAttempt();
-                        break;
-                    case (byte)CustomRPC.ShifterShift:
-                        RPCProcedure.shifterShift(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.SwapperSwap:
-                        byte playerId1 = reader.ReadByte();
-                        byte playerId2 = reader.ReadByte();
-                        RPCProcedure.swapperSwap(playerId1, playerId2);
-                        break;
-                    case (byte)CustomRPC.MorphlingMorph:
-                        RPCProcedure.morphlingMorph(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.CamouflagerCamouflage:
-                        RPCProcedure.camouflagerCamouflage();
-                        break;
-                    case (byte)CustomRPC.VampireSetBitten:
-                        byte bittenId = reader.ReadByte();
-                        byte reset = reader.ReadByte();
-                        RPCProcedure.vampireSetBitten(bittenId, reset);
-                        break;
-                    case (byte)CustomRPC.PlaceGarlic:
-                        RPCProcedure.placeGarlic(reader.ReadBytesAndSize());
-                        break;
-                    case (byte)CustomRPC.TrackerUsedTracker:
-                        RPCProcedure.trackerUsedTracker(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.JackalCreatesSidekick:
-                        RPCProcedure.jackalCreatesSidekick(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.SidekickPromotes:
-                        RPCProcedure.sidekickPromotes();
-                        break;
-                    case (byte)CustomRPC.ErasePlayerRoles:
-                        RPCProcedure.erasePlayerRoles(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.SetFutureErased:
-                        RPCProcedure.setFutureErased(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.SetFutureShifted:
-                        RPCProcedure.setFutureShifted(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.SetFutureShielded:
-                        RPCProcedure.setFutureShielded(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.PlaceJackInTheBox:
-                        RPCProcedure.placeJackInTheBox(reader.ReadBytesAndSize());
-                        break;
-                    case (byte)CustomRPC.LightsOut:
-                        RPCProcedure.lightsOut();
-                        break;
-                    case (byte)CustomRPC.PlaceCamera:
-                        RPCProcedure.placeCamera(reader.ReadBytesAndSize(), reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.SealVent:
-                        RPCProcedure.sealVent(reader.ReadPackedInt32());
-                        break;
-                    case (byte)CustomRPC.ArsonistWin:
-                        RPCProcedure.arsonistWin();
-                        break;
-                    case (byte)CustomRPC.GuesserShoot:
-                        byte killerId = reader.ReadByte();
-                        byte dyingTarget = reader.ReadByte();
-                        byte guessedTarget = reader.ReadByte();
-                        byte guessedRoleType = reader.ReadByte();
-                        RPCProcedure.guesserShoot(killerId, dyingTarget, guessedTarget, guessedRoleType);
-                        break;
-                    case (byte)CustomRPC.VultureWin:
-                        RPCProcedure.vultureWin();
-                        break;
-                    case (byte)CustomRPC.LawyerWin:
-                        RPCProcedure.lawyerWin();
-                        break;
-                    case (byte)CustomRPC.LawyerSetTarget:
-                        RPCProcedure.lawyerSetTarget(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.LawyerPromotesToPursuer:
-                        RPCProcedure.lawyerPromotesToPursuer();
-                        break;
-                    case (byte)CustomRPC.SetBlanked:
-                        var pid = reader.ReadByte();
-                        var blankedValue = reader.ReadByte();
-                        RPCProcedure.setBlanked(pid, blankedValue);
-                        break;
-                    case (byte)CustomRPC.SetFutureSpelled:
-                        RPCProcedure.setFutureSpelled(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.WitchSpellCast:
-                        RPCProcedure.witchSpellCast(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.PlaceAssassinTrace:
-                        RPCProcedure.placeAssassinTrace(reader.ReadBytesAndSize());
-                        break;
+                        case (byte)CustomRPC.EngineerFixLights:
+                            RPCProcedure.engineerFixLights();
+                            break;
+                        case (byte)CustomRPC.EngineerFixSubmergedOxygen:
+                            RPCProcedure.engineerFixSubmergedOxygen();
+                            break;
+                        case (byte)CustomRPC.EngineerUsedRepair:
+                            RPCProcedure.engineerUsedRepair();
+                            break;
+                        case (byte)CustomRPC.CleanBody:
+                            RPCProcedure.cleanBody(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.SheriffKill:
+                            RPCProcedure.sheriffKill(reader.ReadByte(), reader.ReadByte(), reader.ReadBoolean());
+                            break;
+                        case (byte)CustomRPC.TimeMasterRewindTime:
+                            RPCProcedure.timeMasterRewindTime();
+                            break;
+                        case (byte)CustomRPC.TimeMasterShield:
+                            RPCProcedure.timeMasterShield();
+                            break;
+                        case (byte)CustomRPC.MedicSetShielded:
+                            RPCProcedure.medicSetShielded(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.ShieldedMurderAttempt:
+                            RPCProcedure.shieldedMurderAttempt();
+                            break;
+                        case (byte)CustomRPC.ShifterShift:
+                            RPCProcedure.shifterShift(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.SwapperSwap:
+                            byte playerId1 = reader.ReadByte();
+                            byte playerId2 = reader.ReadByte();
+                            RPCProcedure.swapperSwap(playerId1, playerId2);
+                            break;
+                        case (byte)CustomRPC.MorphlingMorph:
+                            RPCProcedure.morphlingMorph(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.CamouflagerCamouflage:
+                            RPCProcedure.camouflagerCamouflage();
+                            break;
+                        case (byte)CustomRPC.VampireSetBitten:
+                            byte bittenId = reader.ReadByte();
+                            byte reset = reader.ReadByte();
+                            RPCProcedure.vampireSetBitten(bittenId, reset);
+                            break;
+                        case (byte)CustomRPC.PlaceGarlic:
+                            RPCProcedure.placeGarlic(reader.ReadBytesAndSize());
+                            break;
+                        case (byte)CustomRPC.TrackerUsedTracker:
+                            RPCProcedure.trackerUsedTracker(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.JackalCreatesSidekick:
+                            RPCProcedure.jackalCreatesSidekick(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.SidekickPromotes:
+                            RPCProcedure.sidekickPromotes();
+                            break;
+                        case (byte)CustomRPC.ErasePlayerRoles:
+                            RPCProcedure.erasePlayerRoles(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.SetFutureErased:
+                            RPCProcedure.setFutureErased(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.SetFutureShifted:
+                            RPCProcedure.setFutureShifted(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.SetFutureShielded:
+                            RPCProcedure.setFutureShielded(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.PlaceJackInTheBox:
+                            RPCProcedure.placeJackInTheBox(reader.ReadBytesAndSize());
+                            break;
+                        case (byte)CustomRPC.LightsOut:
+                            RPCProcedure.lightsOut();
+                            break;
+                        case (byte)CustomRPC.PlaceCamera:
+                            RPCProcedure.placeCamera(reader.ReadBytesAndSize(), reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.SealVent:
+                            RPCProcedure.sealVent(reader.ReadPackedInt32());
+                            break;
+                        case (byte)CustomRPC.ArsonistWin:
+                            RPCProcedure.arsonistWin();
+                            break;
+                        case (byte)CustomRPC.GuesserShoot:
+                            byte killerId = reader.ReadByte();
+                            byte dyingTarget = reader.ReadByte();
+                            byte guessedTarget = reader.ReadByte();
+                            byte guessedRoleType = reader.ReadByte();
+                            RPCProcedure.guesserShoot(killerId, dyingTarget, guessedTarget, guessedRoleType);
+                            break;
+                        case (byte)CustomRPC.VultureWin:
+                            RPCProcedure.vultureWin();
+                            break;
+                        case (byte)CustomRPC.LawyerWin:
+                            RPCProcedure.lawyerWin();
+                            break;
+                        case (byte)CustomRPC.LawyerSetTarget:
+                            RPCProcedure.lawyerSetTarget(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.LawyerPromotesToPursuer:
+                            RPCProcedure.lawyerPromotesToPursuer();
+                            break;
+                        case (byte)CustomRPC.SetBlanked:
+                            var pid = reader.ReadByte();
+                            var blankedValue = reader.ReadByte();
+                            RPCProcedure.setBlanked(pid, blankedValue);
+                            break;
+                        case (byte)CustomRPC.SetFutureSpelled:
+                            RPCProcedure.setFutureSpelled(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.WitchSpellCast:
+                            RPCProcedure.witchSpellCast(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.PlaceAssassinTrace:
+                            RPCProcedure.placeAssassinTrace(reader.ReadBytesAndSize());
+                            break;
 
-                    // GM functionality
-                    case (byte)CustomRPC.AddModifier:
-                        RPCProcedure.addModifier(reader.ReadByte(), reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.SetShifterType:
-                        RPCProcedure.setShifterType(reader.ReadBoolean());
-                        break;
-                    case (byte)CustomRPC.NinjaStealth:
-                        RPCProcedure.ninjaStealth(reader.ReadByte(), reader.ReadBoolean());
-                        break;
-                    case (byte)CustomRPC.ArsonistDouse:
-                        RPCProcedure.arsonistDouse(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.VultureEat:
-                        RPCProcedure.vultureEat(reader.ReadByte());
-                        break;
+                        // GM functionality
+                        case (byte)CustomRPC.AddModifier:
+                            RPCProcedure.addModifier(reader.ReadByte(), reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.SetShifterType:
+                            RPCProcedure.setShifterType(reader.ReadBoolean());
+                            break;
+                        case (byte)CustomRPC.NinjaStealth:
+                            RPCProcedure.ninjaStealth(reader.ReadByte(), reader.ReadBoolean());
+                            break;
+                        case (byte)CustomRPC.ArsonistDouse:
+                            RPCProcedure.arsonistDouse(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.VultureEat:
+                            RPCProcedure.vultureEat(reader.ReadByte());
+                            break;
 
-                    case (byte)CustomRPC.GMKill:
-                        RPCProcedure.GMKill(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.GMRevive:
-                        RPCProcedure.GMRevive(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.UseAdminTime:
-                        RPCProcedure.useAdminTime(reader.ReadSingle());
-                        break;
-                    case (byte)CustomRPC.UseCameraTime:
-                        RPCProcedure.useCameraTime(reader.ReadSingle());
-                        break;
-                    case (byte)CustomRPC.UseVitalsTime:
-                        RPCProcedure.useVitalsTime(reader.ReadSingle());
-                        break;
-                    case (byte)CustomRPC.PlagueDoctorWin:
-                        RPCProcedure.plagueDoctorWin();
-                        break;
-                    case (byte)CustomRPC.PlagueDoctorSetInfected:
-                        RPCProcedure.plagueDoctorInfected(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.PlagueDoctorUpdateProgress:
-                        byte progressTarget = reader.ReadByte();
-                        byte[] progressByte = reader.ReadBytes(4);
-                        float progress = System.BitConverter.ToSingle(progressByte, 0);
-                        RPCProcedure.plagueDoctorProgress(progressTarget, progress);
-                        break;
-                    case (byte)CustomRPC.NekoKabochaExile:
-                        RPCProcedure.nekoKabochaExile(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.SerialKillerSuicide:
-                        RPCProcedure.serialKillerSuicide(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.SwapperAnimate:
-                        RPCProcedure.swapperAnimate();
-                        break;
-                    case (byte)CustomRPC.EvilHackerCreatesMadmate:
-                        RPCProcedure.evilHackerCreatesMadmate(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.FortuneTellerUsedDivine:
-                        byte fId = reader.ReadByte();
-                        byte tId = reader.ReadByte();
-                        RPCProcedure.fortuneTellerUsedDivine(fId, tId);
-                        break;    
-                    case (byte)CustomRPC.FoxStealth:
-                        RPCProcedure.foxStealth(reader.ReadByte(), reader.ReadBoolean());
-                        break;
-                    case (byte)CustomRPC.FoxCreatesImmoralist:
-                        RPCProcedure.foxCreatesImmoralist(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.ImpostorPromotesToLastImpostor:
-                        RPCProcedure.impostorPromotesToLastImpostor(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.SchrodingersCatSuicide:
-                        RPCProcedure.schrodingersCatSuicide();
-                        break;
-                    case (byte)CustomRPC.PlaceTrap:
-                        RPCProcedure.placeTrap(reader.ReadBytesAndSize());
-                        break;
-                    case (byte)CustomRPC.ClearTrap:
-                        RPCProcedure.clearTrap();
-                        break;
-                    case (byte)CustomRPC.ActivateTrap:
-                        RPCProcedure.activateTrap(reader.ReadByte(), reader.ReadByte(), reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.DisableTrap:
-                        RPCProcedure.disableTrap(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.TrapperKill:
-                        RPCProcedure.trapperKill(reader.ReadByte(), reader.ReadByte(), reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.TrapperMeetingFlag:
-                        RPCProcedure.trapperMeetingFlag();
-                        break;
-                    case (byte)CustomRPC.RandomSpawn:
-                        byte pId = reader.ReadByte();
-                        byte locId = reader.ReadByte();
-                        RPCProcedure.randomSpawn(pId, locId);
-                        break;
-                    case (byte)CustomRPC.PlantBomb:
-                        RPCProcedure.plantBomb(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.ReleaseBomb:
-                        RPCProcedure.releaseBomb(reader.ReadByte(), reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.BomberKill:
-                        RPCProcedure.bomberKill(reader.ReadByte(), reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.SpawnDummy:
-                        byte newId = reader.ReadByte();
-                        byte[] spawnTmp = reader.ReadBytes(4);
-                        float spawnX = System.BitConverter.ToSingle(spawnTmp, 0);
-                        spawnTmp = reader.ReadBytes(4);
-                        float spawnY = System.BitConverter.ToSingle(spawnTmp, 0);
-                        spawnTmp = reader.ReadBytes(4);
-                        float spawnZ = System.BitConverter.ToSingle(spawnTmp, 0);
-                        RPCProcedure.spawnDummy(newId, new Vector3(spawnX, spawnY, spawnZ));
-                        break;
-                    case (byte)CustomRPC.MoveDummy:
-                        byte[] moveTmp = reader.ReadBytes(4);
-                        float moveX = System.BitConverter.ToSingle(moveTmp, 0);
-                        moveTmp = reader.ReadBytes(4);
-                        float moveY = System.BitConverter.ToSingle(moveTmp, 0);
-                        moveTmp = reader.ReadBytes(4);
-                        float moveZ = System.BitConverter.ToSingle(moveTmp, 0);
-                        bool spawn = reader.ReadBoolean();
-                        RPCProcedure.moveDummy(new Vector3(moveX, moveY, moveZ), spawn);
-                        break;
-                    case (byte)CustomRPC.WalkDummy:
-                        byte[] walkTmp = reader.ReadBytes(4);
-                        float walkX = System.BitConverter.ToSingle(walkTmp, 0);
-                        walkTmp = reader.ReadBytes(4);
-                        float walkY = System.BitConverter.ToSingle(walkTmp, 0);
-                        RPCProcedure.walkDummy(new Vector3(walkX, walkY, 0f));
-                        break;
-                    case (byte)CustomRPC.PuppeteerStealth:
-                        RPCProcedure.puppeteerStealth(reader.ReadBoolean());
-                        break;
-                    case (byte)CustomRPC.PuppeteerMorph:
-                        RPCProcedure.puppeteerMorph(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.PuppeteerKill:
-                        RPCProcedure.puppeteerKill(reader.ReadByte(), reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.PuppeteerWin:
-                        RPCProcedure.puppeteerWin();
-                        break;
-                    case (byte)CustomRPC.PuppeteerClimbRadder:
-                        RPCProcedure.puppeteerClimbRadder(reader.ReadByte(), reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.mimicMorph:
-                        RPCProcedure.mimicMorph(reader.ReadByte(), reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.mimicResetMorph:
-                        RPCProcedure.mimicResetMorph(reader.ReadByte());
-                        break;
-                    case (byte)CustomRPC.Synchronize:
-                        RPCProcedure.synchronize(reader.ReadByte(),reader.ReadInt32());
-                        break;
+                        case (byte)CustomRPC.GMKill:
+                            RPCProcedure.GMKill(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.GMRevive:
+                            RPCProcedure.GMRevive(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.UseAdminTime:
+                            RPCProcedure.useAdminTime(reader.ReadSingle());
+                            break;
+                        case (byte)CustomRPC.UseCameraTime:
+                            RPCProcedure.useCameraTime(reader.ReadSingle());
+                            break;
+                        case (byte)CustomRPC.UseVitalsTime:
+                            RPCProcedure.useVitalsTime(reader.ReadSingle());
+                            break;
+                        case (byte)CustomRPC.PlagueDoctorWin:
+                            RPCProcedure.plagueDoctorWin();
+                            break;
+                        case (byte)CustomRPC.PlagueDoctorSetInfected:
+                            RPCProcedure.plagueDoctorInfected(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.PlagueDoctorUpdateProgress:
+                            byte progressTarget = reader.ReadByte();
+                            byte[] progressByte = reader.ReadBytes(4);
+                            float progress = System.BitConverter.ToSingle(progressByte, 0);
+                            RPCProcedure.plagueDoctorProgress(progressTarget, progress);
+                            break;
+                        case (byte)CustomRPC.NekoKabochaExile:
+                            RPCProcedure.nekoKabochaExile(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.SerialKillerSuicide:
+                            RPCProcedure.serialKillerSuicide(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.SwapperAnimate:
+                            RPCProcedure.swapperAnimate();
+                            break;
+                        case (byte)CustomRPC.EvilHackerCreatesMadmate:
+                            RPCProcedure.evilHackerCreatesMadmate(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.FortuneTellerUsedDivine:
+                            byte fId = reader.ReadByte();
+                            byte tId = reader.ReadByte();
+                            RPCProcedure.fortuneTellerUsedDivine(fId, tId);
+                            break;    
+                        case (byte)CustomRPC.FoxStealth:
+                            RPCProcedure.foxStealth(reader.ReadByte(), reader.ReadBoolean());
+                            break;
+                        case (byte)CustomRPC.FoxCreatesImmoralist:
+                            RPCProcedure.foxCreatesImmoralist(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.ImpostorPromotesToLastImpostor:
+                            RPCProcedure.impostorPromotesToLastImpostor(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.SchrodingersCatSuicide:
+                            RPCProcedure.schrodingersCatSuicide();
+                            break;
+                        case (byte)CustomRPC.PlaceTrap:
+                            RPCProcedure.placeTrap(reader.ReadBytesAndSize());
+                            break;
+                        case (byte)CustomRPC.ClearTrap:
+                            RPCProcedure.clearTrap();
+                            break;
+                        case (byte)CustomRPC.ActivateTrap:
+                            RPCProcedure.activateTrap(reader.ReadByte(), reader.ReadByte(), reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.DisableTrap:
+                            RPCProcedure.disableTrap(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.TrapperKill:
+                            RPCProcedure.trapperKill(reader.ReadByte(), reader.ReadByte(), reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.TrapperMeetingFlag:
+                            RPCProcedure.trapperMeetingFlag();
+                            break;
+                        case (byte)CustomRPC.RandomSpawn:
+                            byte pId = reader.ReadByte();
+                            byte locId = reader.ReadByte();
+                            RPCProcedure.randomSpawn(pId, locId);
+                            break;
+                        case (byte)CustomRPC.PlantBomb:
+                            RPCProcedure.plantBomb(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.ReleaseBomb:
+                            RPCProcedure.releaseBomb(reader.ReadByte(), reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.BomberKill:
+                            RPCProcedure.bomberKill(reader.ReadByte(), reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.SpawnDummy:
+                            byte newId = reader.ReadByte();
+                            byte[] spawnTmp = reader.ReadBytes(4);
+                            float spawnX = System.BitConverter.ToSingle(spawnTmp, 0);
+                            spawnTmp = reader.ReadBytes(4);
+                            float spawnY = System.BitConverter.ToSingle(spawnTmp, 0);
+                            spawnTmp = reader.ReadBytes(4);
+                            float spawnZ = System.BitConverter.ToSingle(spawnTmp, 0);
+                            RPCProcedure.spawnDummy(newId, new Vector3(spawnX, spawnY, spawnZ));
+                            break;
+                        case (byte)CustomRPC.MoveDummy:
+                            byte[] moveTmp = reader.ReadBytes(4);
+                            float moveX = System.BitConverter.ToSingle(moveTmp, 0);
+                            moveTmp = reader.ReadBytes(4);
+                            float moveY = System.BitConverter.ToSingle(moveTmp, 0);
+                            moveTmp = reader.ReadBytes(4);
+                            float moveZ = System.BitConverter.ToSingle(moveTmp, 0);
+                            bool spawn = reader.ReadBoolean();
+                            RPCProcedure.moveDummy(new Vector3(moveX, moveY, moveZ), spawn);
+                            break;
+                        case (byte)CustomRPC.WalkDummy:
+                            byte[] walkTmp = reader.ReadBytes(4);
+                            float walkX = System.BitConverter.ToSingle(walkTmp, 0);
+                            walkTmp = reader.ReadBytes(4);
+                            float walkY = System.BitConverter.ToSingle(walkTmp, 0);
+                            RPCProcedure.walkDummy(new Vector3(walkX, walkY, 0f));
+                            break;
+                        case (byte)CustomRPC.PuppeteerStealth:
+                            RPCProcedure.puppeteerStealth(reader.ReadBoolean());
+                            break;
+                        case (byte)CustomRPC.PuppeteerMorph:
+                            RPCProcedure.puppeteerMorph(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.PuppeteerKill:
+                            RPCProcedure.puppeteerKill(reader.ReadByte(), reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.PuppeteerWin:
+                            RPCProcedure.puppeteerWin();
+                            break;
+                        case (byte)CustomRPC.PuppeteerClimbRadder:
+                            RPCProcedure.puppeteerClimbRadder(reader.ReadByte(), reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.mimicMorph:
+                            RPCProcedure.mimicMorph(reader.ReadByte(), reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.mimicResetMorph:
+                            RPCProcedure.mimicResetMorph(reader.ReadByte());
+                            break;
+                        case (byte)CustomRPC.Synchronize:
+                            RPCProcedure.synchronize(reader.ReadByte(),reader.ReadInt32());
+                            break;
+                    }
+                } catch(Exception ex) {
+                    Logger.error($"CallID:{callId} {ex}", "CustomRPC");
                 }
             }
         }

--- a/TheOtherRoles/RoleInfo.cs
+++ b/TheOtherRoles/RoleInfo.cs
@@ -306,7 +306,7 @@ namespace TheOtherRoles
             if (p.isRole(RoleType.Immoralist)) infos.Add(immoralist);
             if (p.isRole(RoleType.FortuneTeller))
             {
-                if (includeHidden || PlayerControl.LocalPlayer.Data.IsDead)
+                if (includeHidden || PlayerControl.LocalPlayer ? PlayerControl.LocalPlayer.Data.IsDead : false)
                 {
                     infos.Add(fortuneTeller);
                 }

--- a/TheOtherRoles/Roles/Ninja.cs
+++ b/TheOtherRoles/Roles/Ninja.cs
@@ -204,7 +204,11 @@ namespace TheOtherRoles
             try
             {
                 if (player.MyPhysics?.rend != null)
+                {
+                    if (player.MyPhysics.rend.color != color)
+                        Logger.info($"ChangeOpacity {player.MyPhysics.rend.color.a} to {opacity} of {player.getNameWithRole()}", "setOpacity");
                     player.MyPhysics.rend.color = color;
+                }
 
                 if (player.MyPhysics?.Skin?.layer != null)
                     player.MyPhysics.Skin.layer.color = color;

--- a/TheOtherRoles/Roles/Puppeteer.cs
+++ b/TheOtherRoles/Roles/Puppeteer.cs
@@ -509,7 +509,11 @@ namespace TheOtherRoles
             try
             {
                 if (player.MyPhysics?.rend != null)
+                {
+                    if (player.MyPhysics.rend.color != color)
+                        Logger.info($"ChangeOpacity {player.MyPhysics.rend.color.a} to {opacity} of {player.getNameWithRole()}", "setOpacity");
                     player.MyPhysics.rend.color = color;
+                }
 
                 if (player.MyPhysics?.Skin?.layer != null)
                     player.MyPhysics.Skin.layer.color = color;

--- a/TheOtherRoles/Roles/Role.cs
+++ b/TheOtherRoles/Roles/Role.cs
@@ -328,6 +328,7 @@ namespace TheOtherRoles
 
         public static void setRole(this PlayerControl player, RoleType role)
         {
+            Logger.info($"{player?.Data?.PlayerName}({player?.PlayerId}): {Enum.GetName(typeof(RoleType), role)}", "Player.setRole");
             foreach (var t in RoleData.allRoleTypes)
             {
                 if (role == t.Key)


### PR DESCRIPTION
ログの追加
- setRole（拡張メソッド）
- プレイヤーのスプライトの表示
- モーフィングのログ
- CustomRPCの例外
- ミーティングの呼び出し
- setOpacityの実行
- アビリティボタンの使用ログ
- ゲーム終了時の陣営表示のログ
- 自身の切断とホストの変更のログ

レイアウトの修正
- PadRightをマルチバイトに対応
- CustomHats読み込みログ
- ゲーム開始時のログ
- 投票ログ

