### PR TITLE
人形遣いの修正

### DIFF
--- a/TheOtherRoles/Roles/Puppeteer.cs
+++ b/TheOtherRoles/Roles/Puppeteer.cs
@@ -459,7 +459,7 @@ namespace TheOtherRoles
 
                 // インポスターの位置を示すArrowsを描画
                 foreach(PlayerControl p in PlayerControl.AllPlayerControls){
-                    if(p.Data.IsDead) continue;
+                    if(p.Data.IsDead || p.Data.Role) continue;
                     Arrow arrow;
                     if(p.Data.Role.IsImpostor || p.isRole(RoleType.Jackal) || p.isRole(RoleType.JekyllAndHyde) || p == target)
                     {

--- a/TheOtherRoles/Roles/Puppeteer.cs
+++ b/TheOtherRoles/Roles/Puppeteer.cs
@@ -806,7 +806,7 @@ namespace TheOtherRoles
                     if (Input.GetKeyUp(KeyCode.S))
                         down = false;
 
-                    if(Puppeteer.dummy != null)
+                    if(Puppeteer.dummy != null && !MeetingHud.Instance)
                     {
                         Vector2 pos = Puppeteer.dummy.transform.position;
                         Vector2 offset = Vector2.zero;

--- a/TheOtherRoles/Roles/Puppeteer.cs
+++ b/TheOtherRoles/Roles/Puppeteer.cs
@@ -814,23 +814,24 @@ namespace TheOtherRoles
                         if(down) offset += new Vector2(0f, -0.5f);
                         if(left) offset += new Vector2(-0.5f, 0.0f);
                         if(right) offset += new Vector2(0.5f, 0.0f);
-                        MessageWriter writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.WalkDummy, Hazel.SendOption.Reliable, -1);
-                        writer.Write(offset.x);
-                        writer.Write(offset.y);
-                        AmongUsClient.Instance.FinishRpcImmediately(writer);
-                        RPCProcedure.walkDummy(offset);
-                        if(!(up||down||right||left))
+                        MessageWriter writer;
+                        if(up || down || right || left) //入力があれば動かす
                         {
+                            writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.WalkDummy, Hazel.SendOption.Reliable, -1);
+                            writer.Write(offset.x);
+                            writer.Write(offset.y);
+                            AmongUsClient.Instance.FinishRpcImmediately(writer);
+                            RPCProcedure.walkDummy(offset);
+                        } else if (pos != dummy.NetTransform.targetSyncPosition) { //入力がない&ダミーと現在地と目標にずれがある
                             writer = AmongUsClient.Instance.StartRpcImmediately(PlayerControl.LocalPlayer.NetId, (byte)CustomRPC.MoveDummy, Hazel.SendOption.Reliable, -1);
                             writer.Write(Puppeteer.dummy.transform.position.x);
                             writer.Write(Puppeteer.dummy.transform.position.y);
                             writer.Write(Puppeteer.dummy.transform.position.z);
                             writer.Write(false);
                             AmongUsClient.Instance.FinishRpcImmediately(writer);
-                            // RPCProcedure.moveDummy(Puppeteer.dummy.transform.position);
-                        } 
+                            RPCProcedure.moveDummy(Puppeteer.dummy.transform.position);
+                        }
                     }
-
                 }
             }
         }

--- a/TheOtherRoles/Roles/Puppeteer.cs
+++ b/TheOtherRoles/Roles/Puppeteer.cs
@@ -92,6 +92,7 @@ namespace TheOtherRoles
         public override void OnDeath(PlayerControl killer = null)
         {
             counter -= penaltyOnDeath;
+            setOpacity(player, 1f);
         } 
         public override void HandleDisconnect(PlayerControl player, DisconnectReasons reason) { }
 


### PR DESCRIPTION
人形遣いのバグ修正
- ダミーのまま会議に入り吊られると不透明度がリセットされない問題を修正
- ミーティング中にRPC大量に送る問題を修正
- 操作してないときもRPCが送られる問題を修正
- arrowUpdateの例外の原因になっていたと思われるp.Data.Roleにnullチェックを追加