### PR TITLE
チャットを開いているときにHとIのオーバーレイを禁止

### DIFF
--- a/TheOtherRoles/CustomOverlays.cs
+++ b/TheOtherRoles/CustomOverlays.cs
@@ -537,11 +537,11 @@ namespace TheOtherRoles
         {
             public static void Postfix(KeyboardJoystick __instance)
             {
-                if (Input.GetKeyDown(KeyCode.H) && AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Started)
+                if (Input.GetKeyDown(KeyCode.H) && AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Started && !DestroyableSingleton<ChatController>.Instance.IsOpen)
                 {
                     toggleInfoOverlay();
                 }
-                else if (Input.GetKeyDown(KeyCode.I) && AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Started)
+                else if (Input.GetKeyDown(KeyCode.I) && AmongUsClient.Instance.GameState == InnerNet.InnerNetClient.GameStates.Started && !DestroyableSingleton<ChatController>.Instance.IsOpen)
                 {
                     toggleRoleOverlay();
                 }


### PR DESCRIPTION
チャットの入力中に反応してしまうため、チャットを開いているときにHとIのオーバーレイの切り替えを禁止。