### PR TITLE
透明なプレイヤーも色名が表示される問題を修正

### DIFF
--- a/TheOtherRoles/Roles/Ninja.cs
+++ b/TheOtherRoles/Roles/Ninja.cs
@@ -231,6 +231,9 @@ namespace TheOtherRoles
 
                 if (player.cosmetics.visor != null)
                     player.cosmetics.visor.Image.color = color;
+
+                if (player.cosmetics.colorBlindText != null)
+                    player.cosmetics.colorBlindText.color = color;
             }
             catch { }
         }

--- a/TheOtherRoles/Roles/Puppeteer.cs
+++ b/TheOtherRoles/Roles/Puppeteer.cs
@@ -555,6 +555,9 @@ namespace TheOtherRoles
 
                 if (player.cosmetics.visor != null)
                     player.cosmetics.visor.Image.color = color;
+
+                if (player.cosmetics.colorBlindText != null)
+                    player.cosmetics.colorBlindText.color = color;
             }
             catch { }
         }


### PR DESCRIPTION
色名表示オプション有効時に透明なプレイヤー（ニンジャ・妖狐・パペッティア）も色名が表示される問題を修正
- setOpacityを実行した際にcolorBlindTextを体の透明度と同期する処理を追加