### PR TITLE
RPCのログをRPC名で表示

### DIFF
--- a/TheOtherRoles/Helpers.cs
+++ b/TheOtherRoles/Helpers.cs
@@ -859,5 +859,14 @@ namespace TheOtherRoles
             }
             return false;
         }
+
+        public static string GetRpcName(byte callId)
+        {
+            string rpcName;
+            if ((rpcName = Enum.GetName(typeof(RpcCalls), callId)) != null) { }
+            else if ((rpcName = Enum.GetName(typeof(CustomRPC), callId)) != null) { }
+            else rpcName = callId.ToString();
+            return rpcName;
+        }
     }
 }

--- a/TheOtherRoles/RPC.cs
+++ b/TheOtherRoles/RPC.cs
@@ -1468,7 +1468,7 @@ namespace TheOtherRoles
                 try
                 {
                     CustomRPC rpc = (CustomRPC)packetId;
-                    Logger.info(rpc.ToString(), "RPC");
+                    Logger.info(Helpers.GetRpcName(callId), "RPC");
                     switch (packetId)
                     {
                         // Main Controls


### PR DESCRIPTION
## 変更
- callIdからRPC名を取得するGetRpcNameメソッドを追加
  - RpcCallsとCustomRpcのEnumを確認して該当する文字列を返す
  - いずれも該当しなければIDの文字列型を返す
- RPCのログをGetRpcNameに置換

### 従来のログ
![image](https://user-images.githubusercontent.com/72009106/188498873-8e06b00d-e304-48bd-9106-035bc5f3347f.png)
### GetRpcNameに置換したログ
![image](https://user-images.githubusercontent.com/72009106/188498892-57a5b1e9-9e81-46b0-a26f-3e5b1debb62b.png)
