### PR TITLE
ハットの読み込みで例外が発生する問題を修正

### DIFF
--- a/TheOtherRoles/Modules/CustomHats.cs
+++ b/TheOtherRoles/Modules/CustomHats.cs
@@ -220,11 +220,11 @@ namespace TheOtherRoles.Modules
 
                         List<CustomHat> customhats = createCustomHatDetails(hats);
                         foreach (CustomHat ch in customhats)
-                            __instance.allHats.Add(CreateHatData(ch));
+                            __instance.allHats.AddItem(CreateHatData(ch));
                     }
                     while (CustomHatLoader.hatDetails.Count > 0)
                     {
-                        __instance.allHats.Add(CreateHatData(CustomHatLoader.hatDetails[0]));
+                        __instance.allHats.AddItem(CreateHatData(CustomHatLoader.hatDetails[0]));
                         Logger.info(String.Format("Add CustomHat Author:{0} Name:{1}", CustomHatLoader.hatDetails[0].author.PadRightV2(20), CustomHatLoader.hatDetails[0].name), "CustomHats");
                         CustomHatLoader.hatDetails.RemoveAt(0);
                     }

--- a/TheOtherRoles/TheOtherRoles.csproj
+++ b/TheOtherRoles/TheOtherRoles.csproj
@@ -42,7 +42,7 @@
     </ItemGroup>
 
     <ItemGroup>
-		<PackageReference Include="AmongUs.GameLibs.Steam" Version="2022.8.23" />
+		<PackageReference Include="AmongUs.GameLibs.Steam" Version="2022.10.18" />
         <PackageReference Include="BepInEx.IL2CPP" Version="6.0.0-be.570" />
         <PackageReference Include="BepInEx.IL2CPP.MSBuild" Version="1.1.1" />
     </ItemGroup>


### PR DESCRIPTION
## 概要
ハットの読み込み時にget_allHatsメソッドが見つからず例外が出る問題を修正。

## 原因
アップデートに伴いおそらくallHatsがListではなくArrayに変更された。

## 修正
- ライブラリの更新
- AddからAddItemに修正。