### PR TITLE
カスタムサーバーへの参加待機時間を短縮

### DIFF
--- a/TheOtherRoles/Patches/InnerNetPatch.cs
+++ b/TheOtherRoles/Patches/InnerNetPatch.cs
@@ -1,6 +1,6 @@
 using HarmonyLib;
-using UnhollowerBaseLib;
 using Hazel.Udp;
+using UnhollowerBaseLib;
 namespace TheOtherRoles.Patches
 {
     [HarmonyPatch(typeof(UnityUdpClientConnection), nameof(UnityUdpClientConnection.ConnectAsync))]
@@ -9,7 +9,7 @@ namespace TheOtherRoles.Patches
         public static void Prefix(UnityUdpClientConnection __instance, Il2CppStructArray<byte> bytes)
         {
             __instance.KeepAliveInterval = 2000;
-            __instance.DisconnectTimeoutMs = 15000;
+            __instance.DisconnectTimeoutMs = __instance.EndPoint.Port == 22025 ? 0 : 15000;
         }
     }
 }


### PR DESCRIPTION
## 概要
カスタムサーバーに参加する際に15秒待機する必要があるので改善。

## 変更点
- 22025(DTLS)のポートの通信のみ即タイムアウト
（公式鯖の場合はConnectAsyncで22025使われないので影響なし）